### PR TITLE
Rewired Fix for MouseButton4 Error

### DIFF
--- a/Ricochet/ProjectSettings/InputManager.asset
+++ b/Ricochet/ProjectSettings/InputManager.asset
@@ -6822,6 +6822,22 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
+    m_Name: MouseButton4
+    descriptiveName: Mouse Button 4
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: mouse 4
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
     m_Name: Cancel
     descriptiveName: 
     descriptiveNegativeName: 


### PR DESCRIPTION
Added array element for MouseButton4 to the InputManager. This fixes a Rewired bug on non-Windows systems (I believe) that was causing controls to not function.