### PR TITLE
Fixed UpNOver Colliders

### DIFF
--- a/Ricochet/Assets/_Scenes/RoyLevels/UpNOver.unity
+++ b/Ricochet/Assets/_Scenes/RoyLevels/UpNOver.unity
@@ -895,29 +895,7 @@ Prefab:
       propertyPath: m_Name
       value: OuterWalls
       objectReference: {fileID: 0}
-    - target: {fileID: 4598390923009084, guid: a623c6701db313041b7220613a1f7ba6, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -22.94
-      objectReference: {fileID: 0}
-    - target: {fileID: 4598390923009084, guid: a623c6701db313041b7220613a1f7ba6, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4168832617201572, guid: a623c6701db313041b7220613a1f7ba6, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 22.95
-      objectReference: {fileID: 0}
-    - target: {fileID: 4168832617201572, guid: a623c6701db313041b7220613a1f7ba6, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 61048767815674382, guid: a623c6701db313041b7220613a1f7ba6,
-        type: 2}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 61048767815674382, guid: a623c6701db313041b7220613a1f7ba6, type: 2}
+    m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a623c6701db313041b7220613a1f7ba6, type: 2}
   m_IsPrefabParent: 0
 --- !u!4 &744605802 stripped


### PR DESCRIPTION
The collider on the right wall in UpNOver is missing a collider after Steve's changes; this reverts the OuterWalls prefab to add it back in.